### PR TITLE
Replace deprecated grep-index with grep(:k)

### DIFF
--- a/lib/Hash/MultiValue.pm6
+++ b/lib/Hash/MultiValue.pm6
@@ -150,7 +150,7 @@ method AT-KEY($key) {
 }
 
 method ASSIGN-KEY($key, $value) { 
-    @!all-pairs[ @!all-pairs.grep-index({ .defined && .key eqv $key }) ] :delete;
+    @!all-pairs[ @!all-pairs.grep({ .defined && .key eqv $key }, :k) ] :delete;
     self.add-pairs(($key => $value).list);
     %!singles{$key} = $value;
     $value;
@@ -164,7 +164,7 @@ method ASSIGN-KEY($key, $value) {
 # }
 
 method DELETE-KEY($key) {
-    @!all-pairs[ @!all-pairs.grep-index({ .defined && .key eqv $key }) ] :delete;
+    @!all-pairs[ @!all-pairs.grep({ .defined && .key eqv $key }, :k) ] :delete;
     %!singles{$key} :delete;
 }
 
@@ -203,7 +203,7 @@ method CALL-ME($key) is rw {
             @(@all-pairs.grep({ .defined && .key eqv $key })».value)
         },
         STORE => method (*@new) {
-            @all-pairs[ @all-pairs.grep-index({ .defined && .key eqv $key }) ] :delete;
+            @all-pairs[ @all-pairs.grep({ .defined && .key eqv $key }, :k) ] :delete;
             $self.add-pairs: @new.map($key => *);
             $self.singles{$key} = @new[*-1];
             @new


### PR DESCRIPTION
https://github.com/rakudo/rakudo/commit/c58917725de7eec6ac8f5cffbf5dca96298be19d

grep-index was deprecated since this commit.
